### PR TITLE
Some hotfixes for the advanced custom overlay.

### DIFF
--- a/Resources/CustomCamera/Prefabs/AdvancedTrainerCamera.prefab
+++ b/Resources/CustomCamera/Prefabs/AdvancedTrainerCamera.prefab
@@ -2316,6 +2316,7 @@ MonoBehaviour:
   languagePicker: {fileID: 114615517547003016}
   modePicker: {fileID: 114082708116295526}
   trainingName: DefaultTraining
+  fallbackLanguage: EN
 --- !u!114 &114964195895322434
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
- fix: Now uses other valid language, if system language has no localization file.
- fix: Now uses a fallback language when there are no valid localization files. It is needed for the TTS default field.
- fix: Mode picker is now disabled during active trainings.