### PR TITLE
feat: add locking of objects on scene start

### DIFF
--- a/Resources/CourseController/Prefabs/[COURSE_CONTROLLER].prefab
+++ b/Resources/CourseController/Prefabs/[COURSE_CONTROLLER].prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4221297129693644}
   - component: {fileID: 114632730000728066}
+  - component: {fileID: 4109576349920361998}
   m_Layer: 0
   m_Name: '[COURSE_CONTROLLER]'
   m_TagString: Untagged
@@ -46,3 +47,16 @@ MonoBehaviour:
   courseMode: 0
   courseControllerPrefab: {fileID: 1776092326729858, guid: d58ac3a0c2c7919489afaca3d7019183,
     type: 3}
+--- !u!114 &4109576349920361998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1433457108436006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9e218973d8ce7b141a938229d9877d26, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  lockSceneObjectsOnSceneStart: 1

--- a/Runtime/Utils.meta
+++ b/Runtime/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9c49af93ec888534786eb9ec6c6f692a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Utils/LockObjectsOnSceneStart.cs
+++ b/Runtime/Utils/LockObjectsOnSceneStart.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using Innoactive.Creator.Core.Properties;
+using Innoactive.Creator.Unity;
+using UnityEngine;
+
+namespace Innoactive.Creator.BaseTemplate
+{
+    /// <summary>
+    /// Handles locking of all training scene objects in the scene and makes them non-interactable before the training is started.
+    /// </summary>
+    public class LockObjectsOnSceneStart : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Lock all training scene objects in the scene and makes them non-interactable before the training is started.")]
+        private bool lockSceneObjectsOnSceneStart = true;
+
+        // Start is called before the first frame update
+        void Start()
+        {
+            SceneUtils.GetActiveAndInactiveComponents<LockableProperty>().ToList()
+                .ForEach(lockable => lockable.SetLocked(lockSceneObjectsOnSceneStart));
+        }
+    }
+}

--- a/Runtime/Utils/LockObjectsOnSceneStart.cs.meta
+++ b/Runtime/Utils/LockObjectsOnSceneStart.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e218973d8ce7b141a938229d9877d26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
Add component which handles locking of all training scene objects and add this script to COURSE_CONTROLLER prefab.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- Setup training scene in a clean scene
- Check COURSE_CONTROLLER if component exists
- Create a training with objects and see if you can interact with them before training is started